### PR TITLE
Update inviteflood.c

### DIFF
--- a/inviteflood/inviteflood.c
+++ b/inviteflood/inviteflood.c
@@ -59,7 +59,7 @@ int main (int argc, char *argv[] )
                 destPort = atoi ( optarg );     // Destination port.
                 break;
             case 'l':
-                lineString = optarg;            // Line identifier, needed for SNOM.
+                lineString = strdup(optarg);            // Line identifier, needed for SNOM.
                 break;
             case 's':
                 sleepTimeSec = atol ( optarg ); // Sleep btwn msgs (seconds).


### PR DESCRIPTION
used strdup on the l argument to enable fuzzing the target without causing a crash on the host. as when I use a long string for the "linestring" , it causes a segmentation fault.